### PR TITLE
Add DateAwareTrait->dateString()

### DIFF
--- a/src/Traits/DateAwareTrait.php
+++ b/src/Traits/DateAwareTrait.php
@@ -17,4 +17,16 @@ trait DateAwareTrait
     {
         return new Carbon($this->$key);
     }
+
+    /**
+     * Get a storage-friendly date string for a property
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    public function dateString($key)
+    {
+        return $this->date($key)->format('r');
+    }
 }

--- a/tests/Traits/DateAwareTest.php
+++ b/tests/Traits/DateAwareTest.php
@@ -4,13 +4,23 @@ namespace SparkTests\Data\Traits;
 
 class DateAwareTest extends \PHPUnit_Framework_TestCase
 {
+    private $object;
+
+    protected function setUp()
+    {
+        $this->object = new DateAware;
+        $this->object->at = '2015-10-30 15:05:00';
+    }
+
     public function testDate()
     {
-        $object = new DateAware;
-        $object->at = '2015-10-30 15:05:00';
-
-        $date = $object->date('at');
-
+        $date = $this->object->date('at');
         $this->assertInstanceOf('Carbon\Carbon', $date);
+    }
+
+    public function testDateString()
+    {
+        $date = $this->object->dateString('at');
+        $this->assertSame('Fri, 30 Oct 2015 15:05:00 -0500', $date);
     }
 }

--- a/tests/Traits/DateAwareTest.php
+++ b/tests/Traits/DateAwareTest.php
@@ -21,6 +21,6 @@ class DateAwareTest extends \PHPUnit_Framework_TestCase
     public function testDateString()
     {
         $date = $this->object->dateString('at');
-        $this->assertSame('Fri, 30 Oct 2015 15:05:00 -0500', $date);
+        $this->assertStringStartsWith('Fri, 30 Oct 2015 15:05:00 ', $date);
     }
 }


### PR DESCRIPTION
We're doing this ...

```php
$entity->date('some_attribute')->format('r')
```

... in a few places ...

* [`ShiftTransformer`](https://github.com/wheniwork/api-data-layer/blob/9479f302d3010f88c8343940c1a879239ff6957e/src/Transformer/ShiftTransformer.php#L11-L12)
* [`Transformer`](https://github.com/wheniwork/api-data-layer/blob/9479f302d3010f88c8343940c1a879239ff6957e/src/Transformer/Transformer.php#L22-L28)

To encourage consistency, might be helpful to have a convenient shorthand for it.