### PR TITLE
Allow nested objects to be converted to arrays

### DIFF
--- a/src/ArraySerializableInterface.php
+++ b/src/ArraySerializableInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spark\Data;
+
+interface ArraySerializableInterface
+{
+    /**
+     * Get the values of the object as an array
+     *
+     * @return array
+     */
+    public function toArray();
+}

--- a/src/EntityInterface.php
+++ b/src/EntityInterface.php
@@ -3,6 +3,7 @@
 namespace Spark\Data;
 
 interface EntityInterface extends
+    ArraySerializableInterface,
     \JsonSerializable,
     \Serializable
 {
@@ -23,11 +24,4 @@ interface EntityInterface extends
      * @return static
      */
     public function withData(array $data);
-
-    /**
-     * Get the values of the entity as an array
-     *
-     * @return array
-     */
-    public function toArray();
 }

--- a/src/Traits/ImmutableValueObjectTrait.php
+++ b/src/Traits/ImmutableValueObjectTrait.php
@@ -2,6 +2,8 @@
 
 namespace Spark\Data\Traits;
 
+use Spark\Data\ArraySerializableInterface;
+
 trait ImmutableValueObjectTrait
 {
     /**
@@ -141,7 +143,12 @@ trait ImmutableValueObjectTrait
      */
     public function toArray()
     {
-        return get_object_vars($this);
+        return array_map(static function ($value) {
+            if ($value instanceof ArraySerializableInterface) {
+                $value = $value->toArray();
+            }
+            return $value;
+        }, get_object_vars($this));
     }
 
     /**

--- a/tests/Traits/ImmutableValueObject.php
+++ b/tests/Traits/ImmutableValueObject.php
@@ -2,9 +2,10 @@
 
 namespace SparkTests\Data\Traits;
 
+use Spark\Data\ArraySerializableInterface;
 use Spark\Data\Traits\ImmutableValueObjectTrait;
 
-class ImmutableValueObject
+class ImmutableValueObject implements ArraySerializableInterface
 {
     use ImmutableValueObjectTrait;
 

--- a/tests/Traits/ImmutableValueObjectTest.php
+++ b/tests/Traits/ImmutableValueObjectTest.php
@@ -129,4 +129,22 @@ class ImmutableValueObjectTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('Jonny Jones', $object->name);
         $this->assertSame('JJ', $copied->name);
     }
+
+    public function testToArrayRecursion()
+    {
+        $parent = new ImmutableValueObject([
+            'name' => 'Nested Nero',
+        ]);
+
+        $object = new NestedImmutableValueObject([
+            'parent' => $parent,
+        ]);
+
+        $array  = $object->toArray();
+        $expect = [
+            'parent' => $parent->toArray(),
+        ];
+
+        $this->assertSame($expect, $array);
+    }
 }

--- a/tests/Traits/NestedImmutableValueObject.php
+++ b/tests/Traits/NestedImmutableValueObject.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SparkTests\Data\Traits;
+
+use Spark\Data\ArraySerializableInterface;
+use Spark\Data\Traits\ImmutableValueObjectTrait;
+
+class NestedImmutableValueObject implements ArraySerializableInterface
+{
+    use ImmutableValueObjectTrait;
+
+    private $parent;
+
+    private function expects()
+    {
+        return [
+            'parent' => ImmutableValueObject::class,
+        ];
+    }
+}

--- a/tests/Traits/TypelessImmutableValueObject.php
+++ b/tests/Traits/TypelessImmutableValueObject.php
@@ -2,9 +2,10 @@
 
 namespace SparkTests\Data\Traits;
 
+use Spark\Data\ArraySerializableInterface;
 use Spark\Data\Traits\ImmutableValueObjectTrait;
 
-class TypelessImmutableValueObject
+class TypelessImmutableValueObject implements ArraySerializableInterface
 {
     use ImmutableValueObjectTrait;
 


### PR DESCRIPTION
Often an immutable object will have children or other relationships
that must also be serialized when converting to JSON. By making
`toArray` work recursively on these objects we do not lose data
during conversions.