### PR TITLE
Add immutable collection trait

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spark\Data;
+
+use Spark\Data\Traits\CollectionTrait;
+
+class Collection implements CollectionInterface
+{
+    use CollectionTrait;
+}

--- a/src/CollectionInterface.php
+++ b/src/CollectionInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Spark\Data;
+
+interface CollectionInterface extends
+    ArraySerializableInterface,
+    \Countable,
+    \JsonSerializable,
+    \Serializable
+{
+    /**
+     * Get a copy of the object with an added value
+     *
+     * @param mixed $value
+     *
+     * @return static
+     */
+    public function add($value);
+
+    /**
+     * Check if a value exists in the collection
+     *
+     * @param mixed $value
+     *
+     * @return boolean
+     */
+    public function has($value);
+}

--- a/src/Traits/CollectionTrait.php
+++ b/src/Traits/CollectionTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spark\Data\Traits;
+
+trait CollectionTrait
+{
+    use ImmutableCollectionTrait;
+    use JsonAwareTrait;
+    use SerializeAwareTrait;
+
+    // Serializable
+    public function unserialize($data)
+    {
+        $this->store(unserialize($data));
+    }
+}

--- a/src/Traits/ImmutableCollectionTrait.php
+++ b/src/Traits/ImmutableCollectionTrait.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Spark\Data\Traits;
+
+use Spark\Data\ArraySerializableInterface;
+use SplFixedArray;
+
+trait ImmutableCollectionTrait
+{
+    /**
+     * @var SplFixedArray
+     */
+    private $storage;
+
+    /**
+     * Hydrate the collection with new values
+     *
+     * @param array $values
+     */
+    public function __construct(array $values = [])
+    {
+        $this->store($values);
+    }
+
+    /**
+     * Replace the current storage with new values
+     *
+     * NOTE: Be careful not to violate immutability when using this method!
+     *
+     * @param array $values
+     *
+     * @return void
+     */
+    private function store(array $values)
+    {
+        $this->storage = SplFixedArray::fromArray($values, false);
+    }
+
+    /**
+     * Get a copy of the object with an added value
+     *
+     * @param mixed $value
+     *
+     * @return static
+     */
+    public function add($value)
+    {
+        $values = $this->storage->toArray();
+        array_unshift($values, $value);
+
+        $copy = clone $this;
+        $copy->store($values);
+
+        return $copy;
+    }
+
+    /**
+     * Check if a value exists in the collection
+     *
+     * @param mixed $value
+     *
+     * @return boolean
+     */
+    public function has($value)
+    {
+        return in_array($value, $this->storage->toArray());
+    }
+
+    /**
+     * Get the number of values in the collection
+     *
+     * @return integer
+     */
+    public function count()
+    {
+        return $this->storage->getSize();
+    }
+
+    /**
+     * Get the current collection as an array
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array_map(static function ($value) {
+            if ($value instanceof ArraySerializableInterface) {
+                $value = $value->toArray();
+            }
+            return $value;
+        }, $this->storage->toArray());
+    }
+}

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace SparkTests\Data;
+
+use Spark\Data\Collection;
+
+class CollectionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var array
+     */
+    protected $values;
+
+    /**
+     * @var \Spark\Data\CollectionInterface
+     */
+    protected $collection;
+
+    public function setUp()
+    {
+        $this->values = [
+            'one',
+            'two',
+            'three',
+        ];
+
+        $this->collection = new Collection($this->values);
+    }
+
+    public function testImplements()
+    {
+        $this->assertInstanceOf('Spark\Data\CollectionInterface', $this->collection);
+        $this->assertInstanceOf('Countable', $this->collection);
+        $this->assertInstanceOf('JsonSerializable', $this->collection);
+        $this->assertInstanceOf('Serializable', $this->collection);
+    }
+
+    public function testToArray()
+    {
+        $this->assertSame($this->values, $this->collection->toArray());
+    }
+
+    public function testJsonEncode()
+    {
+        $json = json_encode($this->collection);
+
+        $this->assertJson($json);
+
+        $this->assertSame($this->values, json_decode($json, true));
+    }
+
+    public function testSerialize()
+    {
+        $frozen = serialize($this->collection);
+
+        $this->assertInternalType('string', $frozen);
+
+        $thawed = unserialize($frozen);
+
+        $this->assertInstanceOf(get_class($this->collection), $thawed);
+        $this->assertNotSame($this->collection, $thawed);
+        $this->assertSame($this->values, $thawed->toArray());
+    }
+}

--- a/tests/Traits/ImmutableCollection.php
+++ b/tests/Traits/ImmutableCollection.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SparkTests\Data\Traits;
+
+use Spark\Data\ArraySerializableInterface;
+use Spark\Data\Traits\ImmutableCollectionTrait;
+
+class ImmutableCollection implements
+    ArraySerializableInterface,
+    \Countable
+{
+    use ImmutableCollectionTrait;
+}

--- a/tests/Traits/ImmutableCollectionTest.php
+++ b/tests/Traits/ImmutableCollectionTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SparkTests\Data\Traits;
+
+class ImmutableCollectionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstruction()
+    {
+        $collection = new ImmutableCollection([
+            'a',
+            'b',
+            'c',
+        ]);
+
+        $this->assertTrue($collection->has('a'));
+        $this->assertTrue($collection->has('b'));
+        $this->assertTrue($collection->has('c'));
+        $this->assertFalse($collection->has('d'));
+    }
+
+    public function testAddToCollection()
+    {
+        $collection = new ImmutableCollection;
+        $modified   = $collection->add('bubble');
+
+        $this->assertNotSame($collection, $modified);
+
+        $this->assertFalse($collection->has('bubble'));
+        $this->assertTrue($modified->has('bubble'));
+    }
+
+    public function testToArray()
+    {
+        $values = [
+            'taco',
+            'cake',
+        ];
+
+        $collection = new ImmutableCollection($values);
+
+        $array = $collection->toArray();
+
+        $this->assertSame($values, $array);
+    }
+
+    public function testCount()
+    {
+        $collection = new ImmutableCollection;
+
+        $this->assertSame(0, count($collection));
+
+        $collection = new ImmutableCollection([
+            'tic',
+            'tac',
+        ]);
+
+        $this->assertSame(2, count($collection));
+    }
+
+    public function testToArrayRecursion()
+    {
+        $values = [
+            'Alice',
+            'Ben',
+            'Claire',
+            'Dave',
+        ];
+
+        $collection = new ImmutableCollection(array_map(function ($name) {
+            return new ImmutableValueObject(compact('name'));
+        }, $values));
+
+        $array = $collection->toArray();
+
+        $this->assertCount(4, $array);
+
+        $names = array_column($array, 'name');
+
+        $this->assertSame($values, $names);
+    }
+
+    public function testKeysAreDiscarded()
+    {
+        $values = [
+            'foo' => 'thing',
+            'bar' => 'widget',
+        ];
+
+        $collection = new ImmutableCollection($values);
+
+        $this->assertTrue($collection->has('thing'));
+        $this->assertTrue($collection->has('widget'));
+
+        $array = $collection->toArray();
+
+        $this->assertSame($array, array_values($values));
+    }
+}


### PR DESCRIPTION
In addition to immutable value objects it is often necessary to have
collections of objects. Add traits and interfaces to help create
collections and a base class that can be used for simple cases.