### PR TITLE
Add repository interfaces

### DIFF
--- a/src/Repository/CreateRepositoryInterface.php
+++ b/src/Repository/CreateRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spark\Data\Repository;
+
+interface CreateRepositoryInterface
+{
+    /**
+     * Create a new object and return it
+     *
+     * @param array $values
+     *
+     * @return object
+     */
+    public function create(array $values);
+}

--- a/src/Repository/DeleteRepositoryInterface.php
+++ b/src/Repository/DeleteRepositoryInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Spark\Data\Repository;
+
+interface DeleteRepositoryInterface
+{
+    /**
+     * Delete a single object by identifier
+     *
+     * @param mixed $id
+     *
+     * @return boolean
+     */
+    public function delete($id);
+
+    /**
+     * Delete a single object by variable criteria
+     *
+     * @param array $criteria
+     *
+     * @return boolean
+     */
+    public function deleteOneBy(array $criteria);
+
+    /**
+     * Delete multiple objects by variable criteria
+     *
+     * @param array $criteria
+     * @param array $order_by
+     * @param integer $limit
+     *
+     * @return integer
+     */
+    public function deleteBy(array $criteria, array $order_by = null, $limit = null);
+}

--- a/src/Repository/RepositoryInterface.php
+++ b/src/Repository/RepositoryInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Spark\Data\Repository;
+
+interface RepositoryInterface
+{
+    /**
+     * Find a single object by identifier
+     *
+     * @param mixed $id
+     *
+     * @return object|null
+     */
+    public function find($id);
+
+    /**
+     * Find a single object by variable criteria
+     *
+     * @param array $criteria
+     *
+     * @return object|null
+     */
+    public function findOneBy(array $criteria);
+
+    /**
+     * Find multiple objects by variable criteria
+     *
+     * @param array $criteria
+     * @param array $order_by
+     * @param integer $limit
+     * @param integer $offset
+     *
+     * @return array
+     */
+    public function findBy(array $criteria, array $order_by = null, $limit = null, $offset = null);
+}

--- a/src/Repository/UpdateRepositoryInterface.php
+++ b/src/Repository/UpdateRepositoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spark\Data\Repository;
+
+interface UpdateRepositoryInterface
+{
+    /**
+     * Update an object and return the updated version
+     *
+     * @param integer $id
+     * @param array $values
+     *
+     * @return object
+     */
+    public function update($id, array $values);
+}


### PR DESCRIPTION
Repository pattern is commonly used to abstract data persistence. Add
interfaces that support the standard CRUD operations.

http://www.martinfowler.com/eaaCatalog/repository.html