### PR TITLE
Add interface and trait for object diffing

### DIFF
--- a/src/DiffableInterface.php
+++ b/src/DiffableInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spark\Data;
+
+interface DiffableInterface
+{
+    /**
+     * Find the difference between existing object values
+     *
+     * @param array $changes
+     *
+     * @return array
+     */
+    public function diff(array $values);
+}

--- a/src/Traits/DiffableTrait.php
+++ b/src/Traits/DiffableTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spark\Data\Traits;
+
+use Spark\Data\DiffableInterface;
+
+trait DiffableTrait
+{
+    /**
+     * Get the difference between an object and some values
+     *
+     * @param DiffableInterface $object
+     * @param array $values
+     *
+     * @return array
+     */
+    private function diff(DiffableInterface $object, array $values)
+    {
+        return $object->diff($values);
+    }
+}

--- a/tests/Traits/Diffable.php
+++ b/tests/Traits/Diffable.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SparkTests\Data\Traits;
+
+use Spark\Data\DiffableInterface;
+
+class Diffable implements DiffableInterface
+{
+    public $id;
+    public $name;
+
+    // DiffableInterface
+    public function diff(array $values)
+    {
+        return array_diff_assoc($values, $this->toArray());
+    }
+
+    public function toArray()
+    {
+        return get_object_vars($this);
+    }
+}

--- a/tests/Traits/DiffableTest.php
+++ b/tests/Traits/DiffableTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SparkTests\Data\Traits;
+
+class DiffableTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $this->object = new Diffable;
+        $this->object->id = 42;
+        $this->object->name = 'Life';
+    }
+
+    public function testDiff()
+    {
+        $differ = new ObjectDiffer;
+
+        $changes = $differ->diff($this->object, [
+            'id' => 42,
+            'name' => 'World',
+        ]);
+
+        $this->assertSame(['name' => 'World'], $changes);
+
+        $changes = $differ->diff($this->object, [
+            'id' => 5,
+        ]);
+
+        $this->assertSame(['id' => 5], $changes);
+
+        $changes = $differ->diff($this->object, $this->object->toArray());
+
+        $this->assertEmpty($changes);
+    }
+}

--- a/tests/Traits/ObjectDiffer.php
+++ b/tests/Traits/ObjectDiffer.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SparkTests\Data\Traits;
+
+use Spark\Data\Traits\DiffableTrait;
+
+class ObjectDiffer
+{
+    use DiffableTrait {
+        diff as public;
+    }
+}


### PR DESCRIPTION
Often it is necessary to determine what changes have been made to an
object when persisting data changes. Having a common interfaces makes
it easier to change entity implementations without losing this ability.